### PR TITLE
Implement evaluation draft workflow and status tracking

### DIFF
--- a/call_for_proposal_results.php
+++ b/call_for_proposal_results.php
@@ -52,7 +52,7 @@ if ($totalEvaluators > 0) {
             COALESCE(SUM(es.total_overall_score), 0) AS total_score
         FROM application a
         JOIN organization o ON a.organization_id = o.id
-        LEFT JOIN evaluation e ON e.application_id = a.id
+        LEFT JOIN evaluation e ON e.application_id = a.id AND e.status = \'SUBMITTED\'
         LEFT JOIN (
             SELECT
                 ev.id AS evaluation_id,
@@ -153,6 +153,7 @@ if ($totalEvaluators > 0) {
                 FROM evaluation_thematic_criteria_safeguard
                 GROUP BY evaluation_id
             ) etc_safeguard ON etc_safeguard.evaluation_id = ev.id
+            WHERE ev.status = \'SUBMITTED\'
         ) es ON es.evaluation_id = e.id
         WHERE a.call_for_proposal_id = :call_id
         GROUP BY o.id, o.name

--- a/db/migrations/V24__evaluation_status.sql
+++ b/db/migrations/V24__evaluation_status.sql
@@ -1,0 +1,5 @@
+ALTER TABLE evaluation
+    ADD COLUMN status ENUM('DRAFT', 'SUBMITTED') NOT NULL DEFAULT 'SUBMITTED';
+
+UPDATE evaluation
+SET status = 'SUBMITTED';


### PR DESCRIPTION
## Summary
- add a migration to track evaluation status and update the handler to support draft saves and final submission
- let evaluators resume drafts from the form and expose draft/submitted sections in the listing UI with success messages
- ensure monitoring and ranking views only consider submitted evaluations when aggregating results

## Testing
- php -l evaluation_handler.php
- php -l evaluation_form.php
- php -l evaluations.php
- php -l evaluator_evaluation_overview.php
- php -l call_for_proposal_results.php

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69122cb03308833297cd06eafb42a891)